### PR TITLE
Fix conda_build_config.yaml, bump to 3.0.0rc4

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,6 +1,6 @@
 channel_sources:
 - conda-forge/label/jupyterlab_server_rc,conda-forge/label/jupyterlab_rc,conda-forge,defaults
 channel_targets:
-- conda-forge
+- conda-forge main
 docker_image:
 - condaforge/linux-anvil-comp7

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,2 @@
 channel_sources:
 - conda-forge/label/jupyterlab_server_rc,conda-forge/label/jupyterlab_rc,conda-forge,defaults
-
-channel_targets:
-- conda-forge

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f0ba49cb75b105d5f9e790e0cae5361bc16bb0efae75abf904a8c911861506a6
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script: "{{ PYTHON }} -m pip install . -vv"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f0ba49cb75b105d5f9e790e0cae5361bc16bb0efae75abf904a8c911861506a6
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . -vv"
 
@@ -20,10 +20,10 @@ requirements:
     - pip
     - nodejs
     - jupyter-packaging
-    - jupyterlab >=3.0.0rc0
+    - jupyterlab >=3.0.0rc4
   run:
     - python >=3.6
-    - jupyterlab >=3.0.0rc0
+    - jupyterlab >=3.0.0rc4
 
 test:
   commands:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Attempt at fixing the upload failing on the feedstock creation here:

https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=217336&view=logs&j=47084397-e614-5090-05b8-c04ebacb88b9&t=1f9ba02e-082d-514c-d988-1f2fe7ad8510&l=985

Which seems to be caused by `conda_build_config.yaml` having only one channel:

https://github.com/conda-forge/conda-forge-ci-setup-feedstock/blob/e726e39078cb207f0bdb9c1928465ae359dc076a/recipe/conda_forge_ci_setup/build_utils.py#L146

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
